### PR TITLE
Add setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include W13SCAN/certs/ca.crt
+include W13SCAN/certs/ca.pem
+include W13SCAN/data/wappalyzer.json
+include LICENSE README.md

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,32 @@
+"""Setup file for w13scan."""
+from setuptools import setup, find_packages
+
+with open("README.md", "r") as readme_file:
+    long_description = readme_file.read()
+
+with open("requirements.txt", "r") as requirements_file:
+    install_requires = requirements_file.readlines()
+    install_requires = [i.strip() for i in install_requires]
+
+setup(
+    name="w13scan",
+    version="2.0.2",
+    author="boy-hack",
+    author_email="master@hacking8.com",
+    description="Passive Web Security Scanner",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    keywords="scanner, w13scan",
+    platforms=["any"],
+    url="https://github.com/w-digital-scanner/w13scan",
+    python_requires=">=3.4",
+    packages=find_packages(),
+    install_requires=install_requires,
+    include_package_data=True,
+    classifiers=(
+        "Topic :: Security",
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+    ),
+    entry_points={"console_scripts": ["w13scan = W13SCAN.cli:main"]},
+)


### PR DESCRIPTION
`w13scan` is currently [under review](https://bugzilla.redhat.com/show_bug.cgi?id=1820914) to be included in the Fedora Package Collection.

For 0.9.17 is was using the source which was available at PyPI. Starting with 2.x I would like to switch to the origin upstream location that is GitHub. This means that a setup.py file is needed to perform an installation.