### PR TITLE
update Accept-Encoding header setting

### DIFF
--- a/W13SCAN/lib/proxy/baseproxy.py
+++ b/W13SCAN/lib/proxy/baseproxy.py
@@ -91,8 +91,9 @@ class HttpTransfer(object):
     def set_headers(self, headers):
         headers_tmp = {}
         for k, v in headers.items():
-            if k == "Accept-Encoding" and "br" in v:
-                v = v.replace("br", "")
+            if k.lower() == "accept-encoding" and "br" in v:
+                vl = [x.strip(" ") for x in v.split(",")]
+                v = ", ".join(list(filter(lambda x: x != "br", vl)))
             headers_tmp[k] = v
         self._headers = headers_tmp
 


### PR DESCRIPTION
the original way of handling `Accept-Encoding` header will turn out result below, which is not perfect enough

```python3
>>> 'gzip, br, compress'.replace('br', '')
'gzip, , compress'
```

so I manage another way to solve that problem and open this PR, tests are down below

```python3
>>> vt = ["gzip,br", "br, gzip", "gzip, br,compress", "br"]
>>> for v in vt:
...     vl = [x.strip(" ") for x in v.split(",")]
...     print(", ".join(list(filter(lambda x: x != "br", vl))))
... 
gzip
gzip
gzip, compress

>>>
```